### PR TITLE
Make use of ES6 modules syntax

### DIFF
--- a/app/localforageCordovasqlitedriverDemo.ts
+++ b/app/localforageCordovasqlitedriverDemo.ts
@@ -1,4 +1,4 @@
-import localforage = require('localforage');
+import * as localforage from 'localforage';
 import cordovaSQLiteDriver = require('localforage-cordovasqlitedriver');
 
 console.log(localforage, localforage.driver());


### PR DESCRIPTION
That's all I had to change.  I can compile your project with Typescript 2.0 and 1.8 without any compiler warnings/errors.

It's also possible to import individual functions like this: 

``` ts
import {getItem} from 'localforage'
```
